### PR TITLE
feat: organize questions into categories

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,14 +2,28 @@
 autoLaunch = false
 
 [[redirects]]
-from = "/dynamic/"
+from = "/dynamic/categories/:tag"
 to = "/.netlify/functions/dynamic"
 status = 200
 force = true
 _generated_by_eleventy_serverless = "dynamic"
 
 [[redirects]]
-from = "/on-demand/"
+from = "/categories/:tag"
+to = "/.netlify/builders/on-demand"
+status = 200
+force = true
+_generated_by_eleventy_serverless = "on-demand"
+
+[[redirects]]
+from = "/dynamic/categories/"
+to = "/.netlify/functions/dynamic"
+status = 200
+force = true
+_generated_by_eleventy_serverless = "dynamic"
+
+[[redirects]]
+from = "/categories/"
 to = "/.netlify/builders/on-demand"
 status = 200
 force = true

--- a/pages/_data/questionData.js
+++ b/pages/_data/questionData.js
@@ -19,8 +19,24 @@ const getPublishedQuestions = async () => {
   return publishedQuestions;
 };
 
+const getUniqueCategories = (questions) => {
+  // console.log(JSON.stringify({ questions }, null, 2));
+  return [
+    ...new Set(
+      questions
+        .map((question) => question.Tags)
+        .flat()
+        .sort()
+    ),
+  ];
+};
+
 module.exports = async () => {
   const questions = await getPublishedQuestions();
+  const categories = getUniqueCategories(questions);
 
-  return questions;
+  return {
+    questions,
+    categories,
+  };
 };

--- a/pages/categories/category.njk
+++ b/pages/categories/category.njk
@@ -1,0 +1,35 @@
+---
+title: Categories
+description: Choose one or more categories to focus on, or study everything at once.
+layout: default
+permalink:
+  on-demand: /categories/:tag
+  dynamic: /dynamic/categories/:tag
+---
+
+{% set chosenCategory %}
+  {% for category in questionData.categories %}
+    {% set tag = category | slugify %}
+    {% if tag === eleventy.serverless.path.tag %}
+      {{ category }}
+    {% endif %}
+  {% endfor %}
+{% endset %}
+
+<h1>{{ chosenCategory }}</h1>
+
+{% for question in questionData.questions %}
+  {% if chosenCategory.trim() in question.Tags %}
+    <div>
+      {{ question.Question | mdToHtml | safe }}
+    </div>
+    <details>
+      <summary>
+        Reveal Answer
+      </summary>
+      <div>
+        {{ question.Answer | mdToHtml | safe }}
+      </div>
+    </details>
+  {% endif %}
+{% endfor %}

--- a/pages/categories/index.njk
+++ b/pages/categories/index.njk
@@ -1,0 +1,20 @@
+---
+title: Categories
+description: Choose one or more categories to focus on, or study everything at once.
+layout: default
+permalink:
+  on-demand: /categories/
+  dynamic: /dynamic/categories/
+---
+
+<h1>Categories</h1>
+
+<ul>
+{% for category in questionData.categories %}
+  <li>
+    <a href="/categories/{{ category | slugify }}/">
+      {{ category }}
+    </a>
+  </li>
+{% endfor %}
+</ul>

--- a/pages/index.njk
+++ b/pages/index.njk
@@ -10,9 +10,16 @@ permalink:
 
 <h1>Home Page</h1>
 
-<dl>
 {% for question in questions %}
-  <dt>{{ question.Question }}</dt>
-  <dl>{{ question.Answer | mdToHtml | safe }}</dl>
+  <div>
+    {{ question.Question | mdToHtml | safe }}
+  </div>
+  <details>
+    <summary>
+      Reveal Answer
+    </summary>
+    <div>
+      {{ question.Answer | mdToHtml | safe }}
+    </div>
+  </details>
 {% endfor %}
-</dl>

--- a/pages/index.njk
+++ b/pages/index.njk
@@ -2,24 +2,15 @@
 title: Home
 description: This is the home page.
 layout: default
-permalink:
-  build: /
-  on-demand: /on-demand/
-  dynamic: /dynamic/
 ---
 
 <h1>Home Page</h1>
 
-{% for question in questions %}
-  <div>
-    {{ question.Question | mdToHtml | safe }}
-  </div>
-  <details>
-    <summary>
-      Reveal Answer
-    </summary>
-    <div>
-      {{ question.Answer | mdToHtml | safe }}
-    </div>
-  </details>
-{% endfor %}
+<ul>
+  <li>
+    <a href="/categories/">Categories</a>
+  </li>
+  <li>
+    <a href="/dynamic/categories/">Categories (Dynamic)</a>
+  </li>
+</ul>

--- a/src/layout.njk
+++ b/src/layout.njk
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     {% block titleAndDescription %}
-    <title>{{ title }} | The Pursuit of Trivia</title>
+    <title>{{ title }} | Trivia11y</title>
     <meta name="description" content="{{ description }}">
     {% endblock %}
 


### PR DESCRIPTION
## Description

<!-- Add a description of work done here -->
This work organizes the site into categories. Now there's a listing page with the unique categories in alphabetical order, and clicking on a category link leads to a page with questions related to that category.

## To Validate

<!-- Add steps a reviewer should follow to validate your changes -->

1. Make sure all PR Checks have passed
2. Pull down this branch
3. Run `npm start`
4. Click through the links and verify that everything matches what you would expect based on the data in Airtable
<!-- Add additional validation steps here -->
